### PR TITLE
Allow customising the base URL of the Yum repository

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,12 +17,14 @@
 # @param key_id GPG key to authenticate Apt package signatures.
 # @param key_source The location of an existing GPG key file to copy.
 # @param description Repository description
+# @param rpm_base Base URL for the Yum repository
 class hashi_stack::repo (
   Optional[Integer] $priority = undef,
   String $proxy = 'absent',
   String $key_id = 'E8A032E094D8EB4EA189D270DA418C88A3219F7B',
   Stdlib::HTTPSUrl $key_source = 'https://apt.releases.hashicorp.com/gpg',
   String $description = 'HashiCorp package repository.',
+  String $rpm_base = 'https://rpm.releases.hashicorp.com',
 ) {
   case $facts['os']['family'] {
     'Debian': {
@@ -48,7 +50,7 @@ class hashi_stack::repo (
     'RedHat': {
       yumrepo { 'HashiCorp':
         descr    => $description,
-        baseurl  => 'https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/stable',
+        baseurl  => "${rpm_base}/RHEL/\$releasever/\$basearch/stable",
         gpgcheck => 1,
         gpgkey   => $key_source,
         enabled  => 1,

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -9,7 +9,24 @@ describe 'hashi_stack::repo' do
       when 'Debian'
         it { is_expected.to contain_apt__source('HashiCorp') }
       when 'RedHat'
-        it { is_expected.to contain_yumrepo('HashiCorp') }
+        it {
+          is_expected.to contain_yumrepo('HashiCorp').with(
+            baseurl: 'https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/stable',
+          )
+        }
+        context "with custom Yum base url" do
+          let(:params) do
+            {
+              rpm_base: 'https://somewhere.else'
+            }
+          end
+
+          it {
+            is_expected.to contain_yumrepo('HashiCorp').with(
+              baseurl: 'https://somewhere.else/RHEL/$releasever/$basearch/stable',
+            )
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
Some people might have private mirrors of the repository and would rather to install the software from there.