### PR TITLE
Drop EoL Debian, adjust deps for Puppet 6 & 7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@ fixtures:
   repositories:
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    yum: "https://github.com/voxpupuli/puppet-yum.git"
     yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
       puppet_version: ">= 6.0.0"

--- a/metadata.json
+++ b/metadata.json
@@ -7,23 +7,14 @@
   "source": "https://github.com/voxpupuli/puppet-hashi_stack",
   "project_page": "https://github.com/voxpupuli/puppet-hashi_stack",
   "issues_url": "https://github.com/voxpupuli/puppet-hashi_stack/issues",
-  "description": "This module contains shared code for various HashiCorp modules",
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 5.1.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 8.0.0"
-    },
-    {
-      "name": "puppet/yum",
-      "version_requirement": ">= 0.9.6 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs/yumrepo_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 6.1.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -44,7 +35,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10"
       ]
     },


### PR DESCRIPTION
#### Pull Request (PR) description

Module dependencies were updated minimum versions that support Puppet 6 and max versions that includes the latest releases.

The "description" key was removed as it is no longer supported.

yumrepo_core was also dropped as it is only needed in the fixtures file.

yum was dropped because it is not used within this module
