### PR TITLE
Add support for repo_gpgcheck to the hashicorp yum repo

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -25,6 +25,7 @@ class hashi_stack::repo (
   Stdlib::HTTPSUrl $key_source = 'https://apt.releases.hashicorp.com/gpg',
   String $description = 'HashiCorp package repository.',
   String $rpm_base = 'https://rpm.releases.hashicorp.com',
+  Integer[0,1] $repo_gpgcheck = 0,
 ) {
   case $facts['os']['family'] {
     'Debian': {
@@ -49,13 +50,14 @@ class hashi_stack::repo (
     }
     'RedHat': {
       yumrepo { 'HashiCorp':
-        descr    => $description,
-        baseurl  => "${rpm_base}/RHEL/\$releasever/\$basearch/stable",
-        gpgcheck => 1,
-        gpgkey   => $key_source,
-        enabled  => 1,
-        proxy    => $proxy,
-        priority => $priority,
+        descr         => $description,
+        baseurl       => "${rpm_base}/RHEL/\$releasever/\$basearch/stable",
+        gpgcheck      => 1,
+        gpgkey        => $key_source,
+        repo_gpgcheck => $repo_gpgcheck,
+        enabled       => 1,
+        proxy         => $proxy,
+        priority      => $priority,
       }
     }
     default: {


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for repo_gpgcheck, which should default to 0 since HashiCorp does not sign this repo (vs the RPMs in the repo, which are signed).

#### This Pull Request (PR) fixes the following issues
Without this, RHEL-like nodes with a global `repo_gpgcheck=1` setting will not be able to use this repo.  This global setting is required on many hardened systems.
