### PR TITLE
Fix Ubuntu18/puppet6 CI job

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,6 @@
+# Needed for os.distro.codebase fact on ubuntu 18 on puppet 6
+if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '18.04' and versioncmp($facts['puppetversion'], '7') <= 0 {
+  package{'lsb-release':
+    ensure => present,
+  }
+}


### PR DESCRIPTION
Because of odd packaging decisions at Puppet Inc, the lsb_release tool
is required on Puppet 6 for the distro facts. It's not in the Ubuntu18
base package.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
