### PR TITLE
Add support for AArch64/ARM64 binaries

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -33,7 +33,7 @@ class hashi_stack::repo (
 ) {
   $arch = $facts['os']['architecture'] ? {
     'aarch64' => 'arm64',  # 'aarch64' is official, but Hashicorp uses 'arm64'
-    default   => $facts['os']['architecture']
+    default   => $facts['os']['architecture'],
   }
 
   case $facts['os']['family'] {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -31,13 +31,18 @@ class hashi_stack::repo (
   Integer[0,1] $repo_gpgcheck = 0,
   Integer[0,1] $repo_enabled = 1,
 ) {
+  $arch = $facts['os']['architecture'] ? {
+    'aarch64' => 'arm64',  # 'aarch64' is official, but Hashicorp uses 'arm64'
+    default   => $facts['os']['architecture']
+  }
+
   case $facts['os']['family'] {
     'Debian': {
       include apt
 
       apt::source { 'HashiCorp':
         ensure       => 'present',
-        architecture => 'amd64',
+        architecture => $arch,
         comment      => $description,
         location     => 'https://apt.releases.hashicorp.com',
         repos        => 'main',


### PR DESCRIPTION
Adds support for AArch64/ARM64 binaries located in the Hashicorp Apt repository. When it comes to ARM 64-bit, `aarch64` is the official name for the architecture. However, Hashicorp labels the binaries as `arm64` likely because MacOS also uses `arm64`. This change accounts for the naming difference while continuing to support other architectures.

```console
$ cat /etc/apt/sources.list.d/HashiCorp.list 
# This file is managed by Puppet. DO NOT EDIT.
# HashiCorp package repository.
deb [arch=arm64] https://apt.releases.hashicorp.com bookworm main
```