### PR TITLE
apt::source: Switch from apt-key to new keyrings

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -47,7 +47,7 @@ class hashi_stack::repo (
         location     => 'https://apt.releases.hashicorp.com',
         repos        => 'main',
         key          => {
-          'id'     => $key_id,
+          'name'   => 'hashicorp-archive-keyring.asc',
           'source' => $key_source,
         },
         include      => {


### PR DESCRIPTION
when `name` is not set, the puppetlabs/apt module switches to `apt-key` on the CLI to import the key into the global keyring. This is deprecated since years and not possible with Debian 13.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
